### PR TITLE
Expose get_geometry() / set_geometry() to API

### DIFF
--- a/bindings/storage.i
+++ b/bindings/storage.i
@@ -33,6 +33,7 @@
 #include "storage/Utils/HumanString.h"
 #include "storage/Utils/Region.h"
 #include "storage/Utils/Remote.h"
+#include "storage/Geometry.h"
 
 #include "storage/Devices/Device.h"
 #include "storage/Devices/Filesystem.h"
@@ -77,6 +78,7 @@
 %include "../../storage/Utils/HumanString.h"
 %include "../../storage/Utils/Region.h"
 %include "../../storage/Utils/Remote.h"
+%include "../../storage/Geometry.h"
 
 %include "../../storage/Devices/Device.h"
 %include "../../storage/Devices/Filesystem.h"

--- a/storage/Devices/Partitionable.cc
+++ b/storage/Devices/Partitionable.cc
@@ -32,6 +32,20 @@ namespace storage
     }
 
 
+    const Geometry&
+    Partitionable::get_geometry() const
+    {
+	return get_impl().get_geometry();
+    }
+
+
+    void
+    Partitionable::set_geometry(const Geometry& geometry)
+    {
+	get_impl().set_geometry(geometry);
+    }
+
+
     unsigned int
     Partitionable::get_range() const
     {

--- a/storage/Devices/Partitionable.h
+++ b/storage/Devices/Partitionable.h
@@ -7,6 +7,7 @@
 #include "storage/Devices/BlkDevice.h"
 #include "storage/Devices/PartitionTable.h"
 #include "storage/StorageInterface.h"
+#include "storage/Geometry.h"
 
 
 namespace storage
@@ -19,6 +20,9 @@ namespace storage
     public:
 
 	unsigned int get_range() const;
+
+	const Geometry& get_geometry() const;
+	void set_geometry(const Geometry& geometry);
 
 	/**
 	 * Get the default partition table type for the partitionable.

--- a/storage/Devices/PartitionableImpl.h
+++ b/storage/Devices/PartitionableImpl.h
@@ -4,7 +4,6 @@
 
 #include "storage/Devices/BlkDeviceImpl.h"
 #include "storage/Devices/Partitionable.h"
-#include "storage/Geometry.h"
 
 
 namespace storage

--- a/storage/Geometry.cc
+++ b/storage/Geometry.cc
@@ -33,6 +33,7 @@
 #include "storage/Utils/SystemCmd.h"
 #include "storage/Geometry.h"
 #include "storage/Utils/Enum.h"
+#include "storage/Utils/XmlFile.h"
 
 
 namespace storage

--- a/storage/Geometry.h
+++ b/storage/Geometry.h
@@ -23,12 +23,12 @@
 #ifndef STORAGE_GEOMETRY_H
 #define STORAGE_GEOMETRY_H
 
-#include "storage/Utils/XmlFile.h"
+#include <libxml/tree.h>
 
 
 namespace storage
 {
-
+    // This is a candidate for removal.
     struct Geometry
     {
 	Geometry();

--- a/storage/Makefile.am
+++ b/storage/Makefile.am
@@ -45,6 +45,7 @@ pkginclude_HEADERS =		\
 	Devicegraph.h		\
 	Actiongraph.h		\
 	Graph.h			\
+	Geometry.h		\
 	HumanString.h		\
 	Utils.h
 

--- a/storage/SystemInfo/CmdDasdview.h
+++ b/storage/SystemInfo/CmdDasdview.h
@@ -49,7 +49,7 @@ namespace storage
 
     private:
 
-	void parse(const vector<string>& lines);
+	void parse(const std::vector<string>& lines);
 
 	string device;
 	Geometry geometry;


### PR DESCRIPTION
This is neccessary for setting up faked device graphs from YaML.